### PR TITLE
docs: document JDK 11 requirement for BLE sample

### DIFF
--- a/BluetoothLeGatt/Application/build.gradle
+++ b/BluetoothLeGatt/Application/build.gradle
@@ -49,8 +49,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     sourceSets {

--- a/BluetoothLeGatt/README.md
+++ b/BluetoothLeGatt/README.md
@@ -31,6 +31,7 @@ Pre-requisites
 - Android SDK 28
 - Android Build Tools v28.0.3
 - Android Support Repository
+- JDK 11 (install via `mise use -g java@11` or ensure your JAVA_HOME points to a JDK 11 installation)
 
 Screenshots
 -------------


### PR DESCRIPTION
## Summary
- document JDK 11 requirement for Bluetooth LE GATT sample
- target Java 8 bytecode in the sample's Gradle config

## Testing
- `./gradlew tasks --quiet` *(fails: Could not resolve com.android.tools.build:gradle:4.2.2, received status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_6898e37eaa9483308e0970d4b3071d79